### PR TITLE
ops: add render.yaml for deployment and Dockerize the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 flask_server.log
 venv/
+__pycache__/
+*.pyc
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt gunicorn
+
+COPY . .
+
+ENV PORT=5000
+EXPOSE 5000
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]

--- a/app.py
+++ b/app.py
@@ -90,4 +90,6 @@ def scan_url():
         return jsonify({"error": "Ocurrió un error inesperado en el servidor."}), 500
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    port = int(os.environ.get("PORT", 5000))
+    # En producción, debug debe ser False por seguridad.
+    app.run(host='0.0.0.0', port=port, debug=False)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: link-security-checker
+    env: docker
+    plan: free
+    envVars:
+      - key: VT_API_KEY
+        sync: false
+      - key: PORT
+        value: "5000"


### PR DESCRIPTION
This change introduces a `render.yaml` configuration file for deploying the Link Security Checker to Render. It also provides a robust `Dockerfile` and updates the Flask application to ensure it's production-ready, specifically handling dynamic port binding and disabling debug mode. The `.gitignore` was also updated to keep the repository clean.

Fixes #15

---
*PR created automatically by Jules for task [6128572379958122075](https://jules.google.com/task/6128572379958122075) started by @Villata-dev*